### PR TITLE
Standard docker tag

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,9 +22,9 @@ jobs:
       run:
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
     - name: docker build
-      run: docker build . --file Dockerfile --tag ${{ secrets.DOCKER_USER }}/bw-cli:amd64
+      run: docker build . --file Dockerfile --tag ${{ secrets.DOCKER_USER }}/bw-cli:latest
     - name: docker push
-      run: docker push ${{ secrets.DOCKER_USER }}/bw-cli:amd64
+      run: docker push ${{ secrets.DOCKER_USER }}/bw-cli:latest
 
     - name: push README to Dockerhub
       uses: christian-korneck/update-container-description-action@v1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 The latest Bitwarden CLI in a Docker container.
 
 ## Instructions
-Run `docker build -t bw-cli:amd64 .`
+Run `docker build -t bw-cli:latest .`
 
-Then, `docker run -v $HOME:/root/.config/Bitwarden\ CLI/ -it bw-cli:amd64 login`
+Then, `docker run -v $HOME:/root/.config/Bitwarden\ CLI/ -it bw-cli:latest login`


### PR DESCRIPTION
Use `latest` docker tag for convenience, since I never got around to making multi-arch builds.