### PR TITLE
Busybox

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,8 +25,9 @@ jobs:
         run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - name: docker build
         run: |
-          docker build . --file Dockerfile --tag $DOCKER_USER/bw-cli:latest-scratch \
-          --tag $DOCKER_USER/bw-cli:scratch-${{ github.event.inputs.version }} \
-          --tag $DOCKER_USER/bw-cli:scratch-v${{ github.event.inputs.version }}
+          docker build . --file Dockerfile --tag $DOCKER_USER/bw-cli:latest-busybox \
+          --tag $DOCKER_USER/bw-cli:busybox-latest \
+          --tag $DOCKER_USER/bw-cli:busybox-${{ github.event.inputs.version }} \
+          --tag $DOCKER_USER/bw-cli:busybox-v${{ github.event.inputs.version }}
       - name: docker push
         run: docker push -a $DOCKER_USER/bw-cli

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,9 +25,10 @@ jobs:
         run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - name: docker build
         run: |
-          docker build . --file Dockerfile --tag $DOCKER_USER/bw-cli:latest-busybox \
-          --tag $DOCKER_USER/bw-cli:busybox-latest \
-          --tag $DOCKER_USER/bw-cli:busybox-${{ github.event.inputs.version }} \
-          --tag $DOCKER_USER/bw-cli:busybox-v${{ github.event.inputs.version }}
+          docker build . --file Dockerfile --tag $DOCKER_USER/bw-cli:latest-busybox \|
+            --provenance=mode=max \
+            --tag $DOCKER_USER/bw-cli:busybox-latest \
+            --tag $DOCKER_USER/bw-cli:busybox-${{ github.event.inputs.version }} \
+            --tag $DOCKER_USER/bw-cli:busybox-v${{ github.event.inputs.version }}
       - name: docker push
         run: docker push -a $DOCKER_USER/bw-cli

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,8 +25,8 @@ jobs:
         run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - name: docker build
         run: |
-          docker build . --file Dockerfile --tag $DOCKER_USER/bw-cli:latest \
-          --tag $DOCKER_USER/bw-cli:${{ github.event.inputs.version }} \
-          --tag $DOCKER_USER/bw-cli:v${{ github.event.inputs.version }}
+          docker build . --file Dockerfile --tag $DOCKER_USER/bw-cli:latest-scratch \
+          --tag $DOCKER_USER/bw-cli:scratch-${{ github.event.inputs.version }} \
+          --tag $DOCKER_USER/bw-cli:scratch-v${{ github.event.inputs.version }}
       - name: docker push
         run: docker push -a $DOCKER_USER/bw-cli

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           docker build . --file Dockerfile --tag $DOCKER_USER/bw-cli:latest-busybox \|
             --provenance=mode=max \
+            --sbom=true \
             --tag $DOCKER_USER/bw-cli:busybox-latest \
             --tag $DOCKER_USER/bw-cli:busybox-${{ github.event.inputs.version }} \
             --tag $DOCKER_USER/bw-cli:busybox-v${{ github.event.inputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.env
+*.override.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@
 ###############################################
 FROM --platform=linux/amd64 debian:latest as builder
 ENV DEBIAN_FRONTEND=noninteractive
-
 WORKDIR /usr/local/bin
 
 RUN apt update && apt install -y curl unzip jq
@@ -13,69 +12,25 @@ RUN VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/r
   curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v{$VER}/bw-linux-{$VER}.zip" \
   && unzip *.zip && chmod +x ./bw
 
+RUN mkdir /lib-bw && ldd ./bw | tr -s '[:blank:]' '\n' | grep '^/lib' | xargs -I % cp % /lib-bw
+RUN mkdir /lib64-bw && ldd ./bw | tr -s '[:blank:]' '\n' | grep '^/lib64' | xargs -I % cp % /lib64-bw
+
 ###############################################
 #                  App stage                  #
 ###############################################
-FROM --platform=linux/amd64 scratch as app
-SHELL ["/bin/bash"]
+FROM --platform=linux/amd64 busybox:musl
 
-# binaries
-COPY --from=builder /bin/bash /bin/bash
-COPY --from=builder /usr/bin/curl /usr/bin/curl
-COPY --from=builder /usr/bin/jq /usr/bin/jq
-COPY --from=builder /usr/bin/sleep /usr/bin/sleep
-COPY --from=builder /usr/local/bin/bw /usr/local/bin/bw
+# copy binaries
+COPY --from=builder /usr/local/bin/bw /usr/bin/bw
 
-# shared libraries
-COPY --from=builder /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.6
-COPY --from=builder /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
-COPY --from=builder /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
-COPY --from=builder /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
-COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
-COPY --from=builder /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
-COPY --from=builder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
-COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libselinux.so.1
-COPY --from=builder /lib/x86_64-linux-gnu/libpcre2-8.so.0 /lib/x86_64-linux-gnu/libpcre2-8.so.0
-COPY --from=builder /lib/x86_64-linux-gnu/libonig.so.5 /lib/x86_64-linux-gnu/libonig.so.5
-COPY --from=builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
-COPY --from=builder /lib/x86_64-linux-gnu/libjq.so.1 /lib/x86_64-linux-gnu/libjq.so.1
+# copy shared libraries
+COPY --from=builder /lib-bw /lib
+COPY --from=builder /lib64-bw /lib64
 
-# curl shared libraries
-COPY --from=builder /lib/x86_64-linux-gnu/libcurl.so.4 /lib/x86_64-linux-gnu/libcurl.so.4
-COPY --from=builder /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
-COPY --from=builder /lib/x86_64-linux-gnu/libnghttp2.so.14 /lib/x86_64-linux-gnu/libnghttp2.so.14
-COPY --from=builder /lib/x86_64-linux-gnu/libidn2.so.0 /lib/x86_64-linux-gnu/libidn2.so.0
-COPY --from=builder /lib/x86_64-linux-gnu/librtmp.so.1 /lib/x86_64-linux-gnu/librtmp.so.1
-COPY --from=builder /lib/x86_64-linux-gnu/libssh2.so.1 /lib/x86_64-linux-gnu/libssh2.so.1
-COPY --from=builder /lib/x86_64-linux-gnu/libpsl.so.5 /lib/x86_64-linux-gnu/libpsl.so.5
-COPY --from=builder /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
-COPY --from=builder /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
-COPY --from=builder /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 /lib/x86_64-linux-gnu/libgssapi_krb5.so.2
-COPY --from=builder /lib/x86_64-linux-gnu/libldap-2.5.so.0 /lib/x86_64-linux-gnu/libldap-2.5.so.0
-COPY --from=builder /lib/x86_64-linux-gnu/liblber-2.5.so.0 /lib/x86_64-linux-gnu/liblber-2.5.so.0
-COPY --from=builder /lib/x86_64-linux-gnu/libzstd.so.1 /lib/x86_64-linux-gnu/libzstd.so.1
-COPY --from=builder /lib/x86_64-linux-gnu/libbrotlidec.so.1 /lib/x86_64-linux-gnu/libbrotlidec.so.1
-COPY --from=builder /lib/x86_64-linux-gnu/libunistring.so.2 /lib/x86_64-linux-gnu/libunistring.so.2
-COPY --from=builder /lib/x86_64-linux-gnu/libgnutls.so.30 /lib/x86_64-linux-gnu/libgnutls.so.30
-COPY --from=builder /lib/x86_64-linux-gnu/libhogweed.so.6 /lib/x86_64-linux-gnu/libhogweed.so.6
-COPY --from=builder /lib/x86_64-linux-gnu/libnettle.so.8 /lib/x86_64-linux-gnu/libnettle.so.8
-COPY --from=builder /lib/x86_64-linux-gnu/libgmp.so.10 /lib/x86_64-linux-gnu/libgmp.so.10
-COPY --from=builder /lib/x86_64-linux-gnu/libkrb5.so.3 /lib/x86_64-linux-gnu/libkrb5.so.3
-COPY --from=builder /lib/x86_64-linux-gnu/libk5crypto.so.3 /lib/x86_64-linux-gnu/libk5crypto.so.3
-COPY --from=builder /lib/x86_64-linux-gnu/libcom_err.so.2 /lib/x86_64-linux-gnu/libcom_err.so.2
-COPY --from=builder /lib/x86_64-linux-gnu/libkrb5support.so.0 /lib/x86_64-linux-gnu/libkrb5support.so.0
-COPY --from=builder /lib/x86_64-linux-gnu/libsasl2.so.2 /lib/x86_64-linux-gnu/libsasl2.so.2
-COPY --from=builder /lib/x86_64-linux-gnu/libbrotlicommon.so.1 /lib/x86_64-linux-gnu/libbrotlicommon.so.1
-COPY --from=builder /lib/x86_64-linux-gnu/libp11-kit.so.0 /lib/x86_64-linux-gnu/libp11-kit.so.0
-COPY --from=builder /lib/x86_64-linux-gnu/libtasn1.so.6 /lib/x86_64-linux-gnu/libtasn1.so.6
-COPY --from=builder /lib/x86_64-linux-gnu/libkeyutils.so.1 /lib/x86_64-linux-gnu/libkeyutils.so.1
-COPY --from=builder /lib/x86_64-linux-gnu/libresolv.so.2 /lib/x86_64-linux-gnu/libresolv.so.2
-COPY --from=builder /lib/x86_64-linux-gnu/libffi.so.8 /lib/x86_64-linux-gnu/libffi.so.8
-
-# ca-certificates
+# copy ca-certificates
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # entrypoint
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY entrypoint.sh /usr/bin/entrypoint.sh
 
-ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ FROM --platform=linux/amd64 debian:latest as builder
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /usr/local/bin
-RUN apt update && apt install -y curl unzip libsecret-1-0 jq
+
+RUN apt update && apt install -y curl unzip jq
+
 RUN export VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/bitwarden/clients/releases | jq  -r 'sort_by(.published_at) | reverse | .[].name | select( index("CLI") )' | sed 's:.*CLI v::' | head -n 1) && \
   curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v{$VER}/bw-linux-{$VER}.zip" \
   && unzip *.zip && chmod +x ./bw

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /usr/local/bin
 
 RUN apt update && apt install -y curl unzip jq
 
-RUN export VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/bitwarden/clients/releases | jq  -r 'sort_by(.published_at) | reverse | .[].name | select( index("CLI") )' | sed 's:.*CLI v::' | head -n 1) && \
+RUN VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/bitwarden/clients/releases | jq  -r 'sort_by(.published_at) | reverse | .[].name | select( index("CLI") )' | sed 's:.*CLI v::' | head -n 1) && \
   curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v{$VER}/bw-linux-{$VER}.zip" \
   && unzip *.zip && chmod +x ./bw
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /usr/local/bin
 RUN apt update && apt install -y curl unzip libsecret-1-0 jq
-COPY entrypoint.sh .
 RUN export VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/bitwarden/clients/releases | jq  -r 'sort_by(.published_at) | reverse | .[].name | select( index("CLI") )' | sed 's:.*CLI v::' | head -n 1) && \
   curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v{$VER}/bw-linux-{$VER}.zip" \
   && unzip *.zip && chmod +x ./bw

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM --platform=linux/amd64 debian:latest
+# syntax = docker/dockerfile:1.2
+###############################################
+#                 Build stage                 #
+###############################################
+FROM --platform=linux/amd64 debian:latest as builder
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /usr/local/bin
@@ -7,4 +11,70 @@ COPY entrypoint.sh .
 RUN export VER=$(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/bitwarden/clients/releases | jq  -r 'sort_by(.published_at) | reverse | .[].name | select( index("CLI") )' | sed 's:.*CLI v::' | head -n 1) && \
   curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v{$VER}/bw-linux-{$VER}.zip" \
   && unzip *.zip && chmod +x ./bw
+
+###############################################
+#                  App stage                  #
+###############################################
+FROM --platform=linux/amd64 scratch as app
+SHELL ["/bin/bash"]
+
+# binaries
+COPY --from=builder /bin/bash /bin/bash
+COPY --from=builder /usr/bin/curl /usr/bin/curl
+COPY --from=builder /usr/bin/jq /usr/bin/jq
+COPY --from=builder /usr/bin/sleep /usr/bin/sleep
+COPY --from=builder /usr/local/bin/bw /usr/local/bin/bw
+
+# shared libraries
+COPY --from=builder /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.6
+COPY --from=builder /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=builder /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=builder /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=builder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libselinux.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libpcre2-8.so.0 /lib/x86_64-linux-gnu/libpcre2-8.so.0
+COPY --from=builder /lib/x86_64-linux-gnu/libonig.so.5 /lib/x86_64-linux-gnu/libonig.so.5
+COPY --from=builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=builder /lib/x86_64-linux-gnu/libjq.so.1 /lib/x86_64-linux-gnu/libjq.so.1
+
+# curl shared libraries
+COPY --from=builder /lib/x86_64-linux-gnu/libcurl.so.4 /lib/x86_64-linux-gnu/libcurl.so.4
+COPY --from=builder /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libnghttp2.so.14 /lib/x86_64-linux-gnu/libnghttp2.so.14
+COPY --from=builder /lib/x86_64-linux-gnu/libidn2.so.0 /lib/x86_64-linux-gnu/libidn2.so.0
+COPY --from=builder /lib/x86_64-linux-gnu/librtmp.so.1 /lib/x86_64-linux-gnu/librtmp.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libssh2.so.1 /lib/x86_64-linux-gnu/libssh2.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libpsl.so.5 /lib/x86_64-linux-gnu/libpsl.so.5
+COPY --from=builder /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=builder /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=builder /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 /lib/x86_64-linux-gnu/libgssapi_krb5.so.2
+COPY --from=builder /lib/x86_64-linux-gnu/libldap-2.5.so.0 /lib/x86_64-linux-gnu/libldap-2.5.so.0
+COPY --from=builder /lib/x86_64-linux-gnu/liblber-2.5.so.0 /lib/x86_64-linux-gnu/liblber-2.5.so.0
+COPY --from=builder /lib/x86_64-linux-gnu/libzstd.so.1 /lib/x86_64-linux-gnu/libzstd.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libbrotlidec.so.1 /lib/x86_64-linux-gnu/libbrotlidec.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libunistring.so.2 /lib/x86_64-linux-gnu/libunistring.so.2
+COPY --from=builder /lib/x86_64-linux-gnu/libgnutls.so.30 /lib/x86_64-linux-gnu/libgnutls.so.30
+COPY --from=builder /lib/x86_64-linux-gnu/libhogweed.so.6 /lib/x86_64-linux-gnu/libhogweed.so.6
+COPY --from=builder /lib/x86_64-linux-gnu/libnettle.so.8 /lib/x86_64-linux-gnu/libnettle.so.8
+COPY --from=builder /lib/x86_64-linux-gnu/libgmp.so.10 /lib/x86_64-linux-gnu/libgmp.so.10
+COPY --from=builder /lib/x86_64-linux-gnu/libkrb5.so.3 /lib/x86_64-linux-gnu/libkrb5.so.3
+COPY --from=builder /lib/x86_64-linux-gnu/libk5crypto.so.3 /lib/x86_64-linux-gnu/libk5crypto.so.3
+COPY --from=builder /lib/x86_64-linux-gnu/libcom_err.so.2 /lib/x86_64-linux-gnu/libcom_err.so.2
+COPY --from=builder /lib/x86_64-linux-gnu/libkrb5support.so.0 /lib/x86_64-linux-gnu/libkrb5support.so.0
+COPY --from=builder /lib/x86_64-linux-gnu/libsasl2.so.2 /lib/x86_64-linux-gnu/libsasl2.so.2
+COPY --from=builder /lib/x86_64-linux-gnu/libbrotlicommon.so.1 /lib/x86_64-linux-gnu/libbrotlicommon.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libp11-kit.so.0 /lib/x86_64-linux-gnu/libp11-kit.so.0
+COPY --from=builder /lib/x86_64-linux-gnu/libtasn1.so.6 /lib/x86_64-linux-gnu/libtasn1.so.6
+COPY --from=builder /lib/x86_64-linux-gnu/libkeyutils.so.1 /lib/x86_64-linux-gnu/libkeyutils.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libresolv.so.2 /lib/x86_64-linux-gnu/libresolv.so.2
+COPY --from=builder /lib/x86_64-linux-gnu/libffi.so.8 /lib/x86_64-linux-gnu/libffi.so.8
+
+# ca-certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -29,10 +29,4 @@ services:
     #   - "$HOME/Library/Application Support/Bitwarden CLI:/root/.config/Bitwarden CLI" # macOS
     ports:
       - "127.0.0.1:${SERVE_PORT:-8087}:${SERVE_PORT:-8087}"
-    healthcheck:
-      test: curl -f http://localhost:${SERVE_PORT:-8087}/status || exit 1
-      interval: 5s
-      timeout: 2s
-      retries: 3
-      start_period: 5s
 ```

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # bw-docker
+
 The latest Bitwarden CLI in a Docker container.
 
 ## Instructions
+
 ### Interactive CLI
+
 Run `docker build -t bw-cli:latest .`
 
 Then, `docker run -v $HOME/.config/Bitwarden\ CLI/:/root/.config/Bitwarden\ CLI/ -it bw-cli:latest login`
 
 ### Serve API
+
 Create a local [Vault Management API](https://bitwarden.com/help/vault-management-api/) instance:
 
 `docker-compose.yml`
 ```yaml
-version: "3.3"
 services:
   bw_api:
     container_name: bw_api

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ services:
     container_name: bw_api
     hostname: bw_api
     platform: linux/amd64
-    image: tangowithfoxtrot/bw-cli:${TAG:-latest}
+    image: tangowithfoxtrot/bw-cli:${TAG:-busybox-lastest}
     # environment: # uncomment if you're passing $VAULT_PASSWORD as a secret to unlock the vault
     #   UNLOCK_VAULT: true
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: bw_api
     hostname: bw_api
     platform: linux/amd64
-    image: tangowithfoxtrot/bw-cli:${TAG:-latest}
+    image: tangowithfoxtrot/bw-cli:${TAG:-busybox-latest}
     # build:
     #   context: .
     #   dockerfile: Dockerfile
@@ -16,9 +16,3 @@ services:
     #   - "$HOME/Library/Application Support/Bitwarden CLI:/root/.config/Bitwarden CLI" # macOS
     ports:
       - "127.0.0.1:${SERVE_PORT:-8087}:${SERVE_PORT:-8087}"
-    healthcheck:
-      test: curl -f http://localhost:${SERVE_PORT:-8087}/status || exit 1
-      interval: 5s
-      timeout: 2s
-      retries: 3
-      start_period: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   bw_api:
     container_name: bw_api

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,11 +10,11 @@ STATUS="$(bw status | jq -r '.status')"
 
 if [[ -n "$MFA_CODE" ]]; then
   # shellcheck disable=SC2034
-  export MFA_LOGIN="--method 0 --code $MFA_CODE"
+  MFA_LOGIN="--method 0 --code $MFA_CODE"
 fi
 
 if [[ -n "$BW_CLIENTSECRET" ]]; then
-  export API_LOGIN="--apikey"
+  API_LOGIN="--apikey"
 fi
 
 if [[ "$STATUS" == "unauthenticated" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # to enable interactive CLI usage
 if [[ $# -gt 0 ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ if [ "$UNLOCK_VAULT" = "true" ]; then
     unset BW_TMP_SESSION
   else
     # shellcheck disable=SC2155
-    export BW_SESSION="$(bw unlock --raw)"
+    export BW_SESSION="$(bw unlock --raw "$VAULT_PASSWORD")"
   fi
   sleep 1
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,38 +1,52 @@
-#!/bin/bash
+#!/bin/sh
 
 # to enable interactive CLI usage
-if [[ $# -gt 0 ]]; then
+if [ $# -gt 0 ]; then
   bw "$@"
   exit $?
 fi
 
-STATUS="$(bw status | jq -r '.status')"
+STATUS="$(bw status --pretty | grep 'status' | sed 's/status": "//g' | grep -oE '(\w+)' || echo "Could not get vault status. Exiting..." && exit 1)"
 
-if [[ -n "$MFA_CODE" ]]; then
+if [ -n "$MFA_CODE" ]; then
   # shellcheck disable=SC2034
   MFA_LOGIN="--method 0 --code $MFA_CODE"
 fi
 
-if [[ -n "$BW_CLIENTSECRET" ]]; then
+if [ -n "$BW_CLIENTSECRET" ]; then
   API_LOGIN="--apikey"
 fi
 
-if [[ "$STATUS" == "unauthenticated" ]]; then
+if [ "$STATUS" != "authenticated" ]; then
   bw config server "$SERVER_HOST_URL" && echo
-  # shellcheck disable=SC2086
-  bw login "$VAULT_EMAIL" "$VAULT_PASSWORD" $API_LOGIN $MFA_LOGIN && echo
+  # shellcheck disable=SC2086,SC2155
+  BW_TMP_SESSION="$(bw login --raw "$VAULT_EMAIL" "$VAULT_PASSWORD" $API_LOGIN $MFA_LOGIN)" && echo
+fi
+
+if [ "$UNLOCK_VAULT" = "true" ]; then
+  if [ -n "$BW_TMP_SESSION" ]; then
+    export BW_SESSION="$BW_TMP_SESSION"
+    # unset the temp session key
+    unset BW_TMP_SESSION
+  else
+    # shellcheck disable=SC2155
+    export BW_SESSION="$(bw unlock --raw)"
+  fi
+  sleep 1
+
+  if [ "$(bw status --pretty | grep 'status' | sed 's/status": "//g' | grep -oE '(\w+)')" = "unauthenticated" ]; then
+    echo "Could not authenticate with Bitwarden. Exiting..." && exit 1
+  fi
+
+  echo "Vault unlocked!"
+else
+  # unset the temp session key
+  unset BW_TMP_SESSION
 fi
 
 bw serve --hostname all --port "${SERVE_PORT:-8087}" &
 BW_SERVE_PID=$!
 echo "\`bw serve\` pid: $BW_SERVE_PID"
-
-if [[ "$UNLOCK_VAULT" == "true" ]]; then
-  while ! curl -sX POST -H "Content-Type: application/json" -d "{\"password\": \"$VAULT_PASSWORD\"}" "http://localhost:${SERVE_PORT:-8087}/unlock" >/dev/null; do
-    sleep 1
-  done
-  echo "Vault unlocked!"
-fi
 
 echo "Server can be reached at: http://localhost:${SERVE_PORT:-8087}/status"
 sleep infinity

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ BW_SERVE_PID=$!
 echo "\`bw serve\` pid: $BW_SERVE_PID"
 
 if [[ "$UNLOCK_VAULT" == "true" ]]; then
-  while ! curl -sX POST -H "Content-Type: application/json" -d "{\"password\": \"$VAULT_PASSWORD\"}" "http://localhost:$SERVE_PORT/unlock" >/dev/null; do
+  while ! curl -sX POST -H "Content-Type: application/json" -d "{\"password\": \"$VAULT_PASSWORD\"}" "http://localhost:${SERVE_PORT:-8087}/unlock" >/dev/null; do
     sleep 1
   done
   echo "Vault unlocked!"


### PR DESCRIPTION
- Deprecate the `scratch` image. Using Busybox is simpler with no drawbacks
- Use POSIX-compliant shell script
- Suggest `busybox-latest` as the default image in the README
- Remove dependencies on `curl` and `jq` in the final image stage
- Remove unnecessary `export`s
- Fix bug where the 'Vault unlocked!' message would appear when the vault wasn't actually unlocked
